### PR TITLE
combination of "emtpy" and "move" options

### DIFF
--- a/quickswitch.py
+++ b/quickswitch.py
@@ -98,12 +98,21 @@ def get_workspaces():
 
 def next_empty():
     '''Return the lowest numbered workspace that is empty.'''
-    workspaces = sorted([int(ws) for ws in get_workspaces().keys()
-                         if ws.isdecimal()])
-    for i in range(len(workspaces)):
-        if workspaces[i] != i + 1:
+    workspaces = get_workspaces().keys()
+    numbers = []
+    for ws in workspaces:
+        # find the leading number in ws string (if present)
+        number = ""
+        for c in ws:
+            if not c.isdigit(): break
+            number += str(c)
+        if number: numbers.append(int(number))
+    # remove duplicates, sort
+    numbers = sorted(set(numbers))
+    for i in range(len(numbers)):
+        if numbers[i] != i + 1:
             return str(i + 1)
-    return str(len(workspaces) + 1)
+    return str(numbers[-1] + 1)
 
 
 def next_used(number):

--- a/quickswitch.py
+++ b/quickswitch.py
@@ -240,7 +240,11 @@ def main():
     # the stuff below, as we don't need to call dmenu etc, so we just call it
     # here and exit if the appropriate flag was given.
     if args.empty:
-        exit(*goto_workspace(next_empty()))
+        target_ws=next_empty()
+        if not args.move:
+            exit(*goto_workspace(target_ws))
+        else:
+            exit(*i3.command("move container to workspace {}".format(target_ws)))
 
     # likewise for degapping...
     if args.degap:


### PR DESCRIPTION
Hi,
nice script!

I added the possibility to combine the "emtpy" and "move" options.
I.e., "-me" will move the current container to the next emtpy WS.
This is pretty much the same behaviour as already implemented with "next" and "previous" in combination with "move", so I think it's straight forward to handle this case.

Regards,
Johannes
