### PR TITLE
Open /dev/null for writing in check_dmenu

### DIFF
--- a/quickswitch.py
+++ b/quickswitch.py
@@ -37,7 +37,7 @@ except ImportError:
 
 def check_dmenu():
     '''Check if dmenu is available.'''
-    devnull = open(os.devnull)
+    devnull = open(os.devnull, 'w')
     retcode = subprocess.call(["which", "dmenu"],
                               stdout=devnull,
                               stderr=devnull)


### PR DESCRIPTION
Else, /dev/null will be read-only and (at least debianutils' 4.4+b1)
which will exit with return code 1 because write() failed with EBADF.