### PR TITLE
Adding 'w' on open(os.devnull) to avoid error

### DIFF
--- a/quickswitch.py
+++ b/quickswitch.py
@@ -37,7 +37,7 @@ except ImportError:
 
 def check_dmenu():
     '''Check if dmenu is available.'''
-    devnull = open(os.devnull)
+    devnull = open(os.devnull, 'w')
     retcode = subprocess.call(["which", "dmenu"],
                               stdout=devnull,
                               stderr=devnull)


### PR DESCRIPTION
Should resolve #25  (see also #24).