### PR TITLE
Fix Debian-specific checking for dmenu.

### DIFF
--- a/quickswitch.py
+++ b/quickswitch.py
@@ -37,11 +37,14 @@ except ImportError:
 
 def check_dmenu():
     '''Check if dmenu is available.'''
-    devnull = open(os.devnull)
-    retcode = subprocess.call(["which", "dmenu"],
-                              stdout=devnull,
-                              stderr=devnull)
-    return True if retcode == 0 else False
+    with open(os.devnull, 'w') as devnull:
+        try:
+            retcode = subprocess.call(["dmenu", "-v"],
+                                      stdout=devnull,
+                                      stderr=devnull)
+            return retcode == 0
+        except OSError:
+            return False
 
 
 def dmenu(options, dmenu):


### PR DESCRIPTION
The old check uses ``which``, which is a Debian-specific tool.  The new one
invokes ``dmenu -v`` straight away, so it doesn't depend on external tools.
It's compatible with both Python 3 and Python 2.

It also fixes opening ``/dev/null`` in write mode instead of read-only, plus
it uses ``with`` to ensure that the file is closed.